### PR TITLE
Fix string compare of element names

### DIFF
--- a/srcs/parsing2.c
+++ b/srcs/parsing2.c
@@ -6,7 +6,7 @@
 /*   By: tparratt <tparratt@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/12 13:03:02 by tparratt          #+#    #+#             */
-/*   Updated: 2024/10/22 13:09:46 by tparratt         ###   ########.fr       */
+/*   Updated: 2024/10/24 10:48:23 by tparratt         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,9 +16,9 @@
 (0) a non-map element, (1) an empty line, or (2) part of map element */
 int	identify_line(char *line)
 {
-	if (!ft_strncmp(line, "NO", 2) || !ft_strncmp(line, "SO", 2)
-		|| !ft_strncmp(line, "EA", 2) || !ft_strncmp(line, "WE", 2)
-		|| !ft_strncmp(line, "F", 1) || !ft_strncmp(line, "C", 1))
+	if (!ft_strncmp(line, "NO ", 3) || !ft_strncmp(line, "SO ", 3)
+		|| !ft_strncmp(line, "EA ", 3) || !ft_strncmp(line, "WE ", 3)
+		|| !ft_strncmp(line, "F ", 2) || !ft_strncmp(line, "C ", 2))
 		return (0);
 	else if (!ft_strncmp(line, "\n", 1) || all_whitespace(line))
 		return (1);

--- a/srcs/validation2.c
+++ b/srcs/validation2.c
@@ -6,7 +6,7 @@
 /*   By: tparratt <tparratt@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/12 13:30:49 by tparratt          #+#    #+#             */
-/*   Updated: 2024/10/23 09:51:04 by tparratt         ###   ########.fr       */
+/*   Updated: 2024/10/24 12:08:50 by tparratt         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,8 +20,8 @@ int	invalid_file_extension(char *arg, char *lower, char *upper)
 	str = ft_strchr_rev(arg, '.');
 	if (str == NULL)
 		return (1);
-	if (ft_strncmp(str, lower, ft_strlen(lower)) != 0
-		&& ft_strncmp(str, upper, ft_strlen(upper)) != 0)
+	if (ft_strncmp(str, lower, ft_strlen(lower) + 1) != 0
+		&& ft_strncmp(str, upper, ft_strlen(upper) + 1) != 0)
 		return (1);
 	return (0);
 }


### PR DESCRIPTION
The program was not checking the element names correctly. This is now fixed by checking that they are followed by a space.